### PR TITLE
fix(otel): driver should manually set legacy prom metric scheme

### DIFF
--- a/examples/all/metrics_otel_generated.go
+++ b/examples/all/metrics_otel_generated.go
@@ -3,9 +3,15 @@ package all
 
 import (
 	"context"
+	prommodel "github.com/prometheus/common/model"
 	otelattribute "go.opentelemetry.io/otel/attribute"
 	otelmetricsdk "go.opentelemetry.io/otel/metric"
 )
+
+// FIXME:hack for conformance tests, consistent metric exposing with prometheus driver
+func init() {
+	prommodel.NameValidationScheme = prommodel.LegacyValidation
+}
 
 // EnumExampleEnum Example enum
 type EnumExampleEnum string

--- a/examples/benchmark/otel/metrics_otel_generated.go
+++ b/examples/benchmark/otel/metrics_otel_generated.go
@@ -3,9 +3,15 @@ package benchmark
 
 import (
 	"context"
+	prommodel "github.com/prometheus/common/model"
 	otelattribute "go.opentelemetry.io/otel/attribute"
 	otelmetricsdk "go.opentelemetry.io/otel/metric"
 )
+
+// FIXME:hack for conformance tests, consistent metric exposing with prometheus driver
+func init() {
+	prommodel.NameValidationScheme = prommodel.LegacyValidation
+}
 
 type Metrics struct {
 	*MetricEightLabelCounter

--- a/examples/example/metrics/metrics_otel_generated.go
+++ b/examples/example/metrics/metrics_otel_generated.go
@@ -3,9 +3,15 @@ package metrics
 
 import (
 	"context"
+	prommodel "github.com/prometheus/common/model"
 	otelattribute "go.opentelemetry.io/otel/attribute"
 	otelmetricsdk "go.opentelemetry.io/otel/metric"
 )
+
+// FIXME:hack for conformance tests, consistent metric exposing with prometheus driver
+func init() {
+	prommodel.NameValidationScheme = prommodel.LegacyValidation
+}
 
 // EnumCpuMode cpu state
 type EnumCpuMode string

--- a/examples/merge/metrics_otel_generated.go
+++ b/examples/merge/metrics_otel_generated.go
@@ -3,9 +3,15 @@ package merge
 
 import (
 	"context"
+	prommodel "github.com/prometheus/common/model"
 	otelattribute "go.opentelemetry.io/otel/attribute"
 	otelmetricsdk "go.opentelemetry.io/otel/metric"
 )
+
+// FIXME:hack for conformance tests, consistent metric exposing with prometheus driver
+func init() {
+	prommodel.NameValidationScheme = prommodel.LegacyValidation
+}
 
 type Metrics struct {
 	*MetricExampleCounter

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/main.go
+++ b/main.go
@@ -108,6 +108,10 @@ func BuildGenerateCmd() *cobra.Command {
 							Alias:      "otelattribute",
 							Dependency: "go.opentelemetry.io/otel/attribute",
 						},
+						{
+							Alias:      "prommodel",
+							Dependency: "github.com/prometheus/common/model",
+						},
 					},
 					Metrics:   cfg.ToMetricsTemplateDefinition(),
 					EnumTypes: cfg.ToEnumTemplateDefinition(),

--- a/pkg/templates/templates/metrics.otel.go.tmpl
+++ b/pkg/templates/templates/metrics.otel.go.tmpl
@@ -11,6 +11,11 @@ import (
   {{- end }}
 )
 
+//FIXME:hack for conformance tests, consistent metric exposing with prometheus driver
+func init () {
+  prommodel.NameValidationScheme = prommodel.LegacyValidation
+}
+
 {{- range $enum := .EnumTypes }}
 {{ if not (eq $enum.Description "")}}// {{$enum.EnumType}} {{ $enum.Description }}{{- end }}
 type {{ $enum.EnumType }} {{ $enum.ValueType }}


### PR DESCRIPTION
Indirectly related to https://github.com/open-telemetry/opentelemetry-go/issues/6704